### PR TITLE
Add .gitignore & clean paths to use relative paths with 'path' utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "peerDependencies": {},
   "scripts": {
-    "build": "webpack --config /react/webpack/webpack.config.js -p --display-error-details --progress --optimize-minimize",
-    "dev:hot": "webpack-dev-server --config /react/webpack/webpack.config-dev.js"
+    "build": "webpack --config webpack/webpack.config.js -p --display-error-details --progress --optimize-minimize",
+    "dev:hot": "webpack-dev-server --config webpack/webpack.config-dev.js"
   },
   "keywords": [
     "community",
@@ -62,10 +62,9 @@
     "open-source-software"
   ],
   "repository": {
-    "type" : "git"
-  , "url" : "https://github.com/mac-s-g/github-help-wanted.git"
+    "type": "git",
+    "url": "https://github.com/mac-s-g/github-help-wanted.git"
   },
-  "keywords": [],
   "bugs": {
     "url": "https://github.com/mac-s-g/github-help-wanted/issues/"
   },

--- a/src/js/containers/Index.js
+++ b/src/js/containers/Index.js
@@ -3,9 +3,9 @@ import Layout from './../components/layout/Main'
 import { Provider } from 'react-redux'
 
 import 'semantic-ui-css/semantic.min.css'
-import '/react/src/style/scss/global.scss'
+import '../../style/scss/global.scss'
 
-export default ({store}) => (
+export default ({ store }) => (
   <Provider store={store}>
     <Layout />
   </Provider>

--- a/webpack/webpack.config-dev.js
+++ b/webpack/webpack.config-dev.js
@@ -3,15 +3,15 @@ const webpack = require('webpack');
 const wds_port = 3100;
 
 const PATHS = {
-    src: '/react/src',
-    js: '/react/src/js',
-    style: '/react/src/style',
-    build: '/react/dev-server/dist',
-    devServer: '/react/dev-server',
+  src: path.join(__dirname, '..', 'src'),
+  js: path.join(__dirname, '..', 'src', 'js'),
+  style: path.join(__dirname, '..', 'src', 'style'),
+  build: path.join(__dirname, '..', 'dev-server', 'dist'),
+  devServer: path.join(__dirname, '..', 'dev-server'),
 };
 
 const config = {
-  entry: [PATHS.devServer + '/js/entry.js'],
+  entry: [path.join(PATHS.devServer, 'js', 'entry.js')],
   externals: {},
   devServer: {
     host: '0.0.0.0',

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -3,14 +3,14 @@ const webpack = require('webpack');
 const wds_port = 3100;
 
 const PATHS = {
-    src: '/react/src',
-    js: '/react/src/js',
-    style: '/react/src/style',
-    build: '/react/dist'
+  src: path.join(__dirname, '..', 'src'),
+  js: path.join(__dirname, '..', 'src', 'js'),
+  style: path.join(__dirname, '..', 'src', 'style'),
+  build: path.join(__dirname, '..', 'dev-server', 'dist'),
 };
 
 const config = {
-  entry: [PATHS.js + '/entry.js'],
+  entry: [path.join(PATHS.js, 'entry.js')],
   externals: {},
   output: {
     path: PATHS.build,


### PR DESCRIPTION
I was not able to run the app (without Docker) because of absolute paths in source. There is no need to use absolute paths, relative paths work well with Webpack and Node (the safest way with Node being using *path* utility to join path parts on any OS). I hope this doesn't break Docker build; I didn't succeed to run Docker bu I'm really not an expert with it, that's why I used plain npm-style 😉