### PR TITLE
Fix typo on home page

### DIFF
--- a/src/js/components/layout/Main.js
+++ b/src/js/components/layout/Main.js
@@ -32,7 +32,7 @@ const FixedMenuLayout = () => (
               <Header.Subheader>
                 <p>Open-Source projects are looking for your help.</p>
                 <p>
-                  Below are recent issues that maintainers lablelled as{" "}
+                  Below are recent issues that maintainers labelled as{" "}
                   <i>help wanted</i>.
                 </p>
                 <p>


### PR DESCRIPTION
"lablelled" => "labelled"