### PR TITLE
Add hacktoberfest label to search filter of labels

### DIFF
--- a/src/js/constants.js
+++ b/src/js/constants.js
@@ -98,6 +98,7 @@ const constants = {
       "feature",
       "first-timers-only",
       "good first issue",
+      "hacktoberfest",
       "hard",
       "help wanted",
       "jump-in",


### PR DESCRIPTION
Recently, this year's Hacktoberfest started.

https://hacktoberfest.digitalocean.com

I want to search issues with hacktoberfest label by 'GitHub help wanted', but there is no hacktober label in search filter.

This PR adds hacktoberfest label to search filter of labels