### PR TITLE
Clicking on logo redirects to home

### DIFF
--- a/src/js/components/layout/Navbar.js
+++ b/src/js/components/layout/Navbar.js
@@ -11,7 +11,7 @@ const Navbar = () => (
   <div>
     <Menu attached="top" inverted as={HeaderComponent}>
       <Container>
-        <Menu.Item as="a" header>
+        <Menu.Item as="a" href="http://github-help-wanted.com/" header>
           <Logo size="large" />
         </Menu.Item>
         <Menu.Menu position="right">


### PR DESCRIPTION
Previously clicking on the logo on navbar didnt do anything, now it redirects to the home page (http://github-help-wanted.com/)
I tested it and it could successfully redirect from localhost:3100 to http://github-help-wanted.com/